### PR TITLE
Implemented Date Selector when Adding New Habit

### DIFF
--- a/app/src/main/java/com/example/habitsmasher/ui/dashboard/AddHabitDialog.java
+++ b/app/src/main/java/com/example/habitsmasher/ui/dashboard/AddHabitDialog.java
@@ -34,24 +34,31 @@ import java.util.Date;
  *
  * Name: Mitch Tabian
  * Video Date: December 10, 2017
+ *
+ * Adding a DatePickerDialog came from the following video:
+ * https://www.youtube.com/watch?v=AdTzD96AhE0
+ *
+ * Name: Mitch Tabian
+ * Video Date: March 11, 2019
  */
 public class AddHabitDialog extends DialogFragment implements DatePickerDialog.OnDateSetListener {
 
     private static final String TAG = "AddHabitDialog";
-    private String DATE_FORMAT = "dd-MM-yyyy";
-    private String INCORRECT_TITLE_FORMAT = "Incorrect habit title entered";
-    private String INCORRECT_REASON_FORMAT = "Incorrect habit reason entered";
-    private String INCORRECT_BLANK_DATE = "Please enter a start date";
-    private String INCORRECT_DATE_FORMAT = "Habit start date format: dd-mm-yyyy";
+    private final String DATE_FORMAT = "dd/MM/yyyy";
+    private final String INCORRECT_TITLE_FORMAT = "Incorrect habit title entered";
+    private final String INCORRECT_REASON_FORMAT = "Incorrect habit reason entered";
+    private final String INCORRECT_BLANK_DATE = "Please enter a start date";
 
     private HabitListFragment _habitListFragment;
     private EditText _habitTitleEditText;
     private EditText _habitReasonEditText;
-    private EditText _habitDateEditText;
     private Button _confirmNewHabit;
     private Button _cancelNewHabit;
     private TextView _habitDateTextView;
     private boolean _invalidDate = false;
+    private String _habitTitleInput;
+    private String _habitReasonInput;
+    private Date _habitDate;
 
     @Nullable
     @Override
@@ -59,7 +66,6 @@ public class AddHabitDialog extends DialogFragment implements DatePickerDialog.O
         View view = inflater.inflate(R.layout.add_habit_dialog_box, container, false);
         _habitTitleEditText = view.findViewById(R.id.habit_title_edit_text);
         _habitReasonEditText = view.findViewById(R.id.habit_reason_edit_text);
-        //_habitDateEditText = view.findViewById(R.id.habit_date_edit_text);
         _habitDateTextView = view.findViewById(R.id.habit_date_selection);
         _confirmNewHabit = view.findViewById(R.id.confirm_habit);
         _cancelNewHabit = view.findViewById(R.id.cancel_habit);
@@ -70,6 +76,7 @@ public class AddHabitDialog extends DialogFragment implements DatePickerDialog.O
                 openDatePickerDialog();
             }
         });
+
         _cancelNewHabit.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -83,52 +90,10 @@ public class AddHabitDialog extends DialogFragment implements DatePickerDialog.O
             @Override
             public void onClick(View view) {
                 Log.d(TAG, "Confirm");
-
-                String habitTitleInput = _habitTitleEditText.getText().toString();
-                String habitReasonInput = _habitReasonEditText.getText().toString();
-                String habitDateInput = _habitDateEditText.getText().toString();
-
-                DateFormat inputDateFormatter = new SimpleDateFormat(DATE_FORMAT);
-                Date habitDate = null;
-
-                try {
-                    inputDateFormatter.setLenient(false);
-                    habitDate = inputDateFormatter.parse(habitDateInput);
-                } catch (ParseException e) {
-                    _invalidDate = true;
-                    e.printStackTrace();
-                }
-
-                /**
-                 * When user input meets the requirements for a proper habit title, habit reason, and habit date,
-                 * have the habit be added to the habit list back in dashboard fragment.
-                 */
-                if (((habitTitleInput.length()>0)&&(habitTitleInput.length()<=20))&&
-                        ((habitReasonInput.length()>0)&&(habitReasonInput.length()<=30))&&
-                        (!(habitDateInput.equals("")))&&
-                        (!(_invalidDate))
-                ) {
-                    _habitListFragment.addNewHabit(new Habit(habitTitleInput, habitReasonInput, habitDate));
-                    _habitListFragment.addHabitToDatabase(habitTitleInput, habitReasonInput, habitDate);
+                if (checkNewHabitIsValid()){
+                    _habitListFragment.addNewHabit(new Habit(_habitTitleInput, _habitReasonInput, _habitDate));
+                    _habitListFragment.addHabitToDatabase(_habitTitleInput, _habitReasonInput, _habitDate);
                     getDialog().dismiss();
-                } else{
-
-                    //Handle error checking for new habit name/title
-                    if ((!(habitTitleInput.length()>0)) || (!(habitTitleInput.length()<=20))){
-                        Toast.makeText(getActivity(), INCORRECT_TITLE_FORMAT, Toast.LENGTH_SHORT).show();
-                    }
-
-                    //Handle error checking for new habit reason
-                    if ((!(habitReasonInput.length()>0)) || (!(habitReasonInput.length()<=30))){
-                        Toast.makeText(getActivity(), INCORRECT_REASON_FORMAT, Toast.LENGTH_SHORT).show();
-                    }
-
-                    //Handle error checking for new habit date.
-                    if ((habitDateInput.equals(""))){
-                        Toast.makeText(getActivity(), INCORRECT_BLANK_DATE, Toast.LENGTH_SHORT).show();
-                    } else if(_invalidDate==true){
-                        Toast.makeText(getActivity(), INCORRECT_DATE_FORMAT, Toast.LENGTH_SHORT).show();
-                    }
                 }
             }
         });
@@ -147,11 +112,65 @@ public class AddHabitDialog extends DialogFragment implements DatePickerDialog.O
         datePickerDialog.show();
     }
 
+
     @Override
     public void onDateSet(DatePicker view, int year, int month, int day) {
+        //1 is added to the month we get from the DatePickerDialog
+        // because DatePickerDialog returns values between 0 and 11,
+        // which is not really helpful for users.
         int correctedMonth = month + 1;
         String date = day + "/" + correctedMonth + "/" + year;
         _habitDateTextView.setText(date);
+    }
+
+    /**
+     * Returns boolean so habit can be added to habit list or not.
+     * @return true if all fields are entered correctly, false otherwise.
+     */
+    private boolean checkNewHabitIsValid(){
+        _invalidDate = false;
+        _habitTitleInput = _habitTitleEditText.getText().toString();
+        _habitReasonInput = _habitReasonEditText.getText().toString();
+
+        DateFormat inputDateFormatter = new SimpleDateFormat(DATE_FORMAT);
+        _habitDate = null;
+
+        try {
+            inputDateFormatter.setLenient(false);
+            _habitDate = inputDateFormatter.parse(_habitDateTextView.getText().toString());
+        } catch (ParseException e) {
+            _invalidDate = true;
+            e.printStackTrace();
+        }
+
+        /**
+         * When user input meets the requirements for a proper habit title, habit reason, and habit date,
+         * have the habit be added to the habit list back in dashboard fragment.
+         */
+        if (
+                ((_habitTitleInput.length()>0)&&(_habitTitleInput.length()<=20))&&
+                ((_habitReasonInput.length()>0)&&(_habitReasonInput.length()<=30))&&
+                (_invalidDate==false)
+        ) {
+            return true;
+        } else {
+
+            //Handle error checking for new habit name/title
+            if ((!(_habitTitleInput.length()>0)) || (!(_habitTitleInput.length()<=20))){
+                Toast.makeText(getActivity(), INCORRECT_TITLE_FORMAT, Toast.LENGTH_SHORT).show();
+            }
+
+            //Handle error checking for new habit reason
+            if ((!(_habitReasonInput.length()>0)) || (!(_habitReasonInput.length()<=30))){
+                Toast.makeText(getActivity(), INCORRECT_REASON_FORMAT, Toast.LENGTH_SHORT).show();
+            }
+
+            //Handle error checking for new habit date.
+            if (_invalidDate==true){
+                Toast.makeText(getActivity(), INCORRECT_BLANK_DATE, Toast.LENGTH_SHORT).show();
+            }
+            return false;
+        }
     }
 
     @Override

--- a/app/src/main/java/com/example/habitsmasher/ui/dashboard/AddHabitDialog.java
+++ b/app/src/main/java/com/example/habitsmasher/ui/dashboard/AddHabitDialog.java
@@ -1,5 +1,6 @@
 package com.example.habitsmasher.ui.dashboard;
 
+import android.app.DatePickerDialog;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
@@ -8,7 +9,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.DatePicker;
 import android.widget.EditText;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -22,6 +25,7 @@ import com.example.habitsmasher.R;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 
 /**
@@ -31,7 +35,7 @@ import java.util.Date;
  * Name: Mitch Tabian
  * Video Date: December 10, 2017
  */
-public class AddHabitDialog extends DialogFragment{
+public class AddHabitDialog extends DialogFragment implements DatePickerDialog.OnDateSetListener {
 
     private static final String TAG = "AddHabitDialog";
     private String DATE_FORMAT = "dd-MM-yyyy";
@@ -46,6 +50,7 @@ public class AddHabitDialog extends DialogFragment{
     private EditText _habitDateEditText;
     private Button _confirmNewHabit;
     private Button _cancelNewHabit;
+    private TextView _habitDateTextView;
     private boolean _invalidDate = false;
 
     @Nullable
@@ -54,10 +59,17 @@ public class AddHabitDialog extends DialogFragment{
         View view = inflater.inflate(R.layout.add_habit_dialog_box, container, false);
         _habitTitleEditText = view.findViewById(R.id.habit_title_edit_text);
         _habitReasonEditText = view.findViewById(R.id.habit_reason_edit_text);
-        _habitDateEditText = view.findViewById(R.id.habit_date_edit_text);
+        //_habitDateEditText = view.findViewById(R.id.habit_date_edit_text);
+        _habitDateTextView = view.findViewById(R.id.habit_date_selection);
         _confirmNewHabit = view.findViewById(R.id.confirm_habit);
         _cancelNewHabit = view.findViewById(R.id.cancel_habit);
 
+        _habitDateTextView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                openDatePickerDialog();
+            }
+        });
         _cancelNewHabit.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -123,6 +135,25 @@ public class AddHabitDialog extends DialogFragment{
 
         return view;
     }
+
+    private void openDatePickerDialog(){
+        DatePickerDialog datePickerDialog = new DatePickerDialog(
+                getActivity(),
+                this,
+                Calendar.getInstance().get(Calendar.YEAR),
+                Calendar.getInstance().get(Calendar.MONTH),
+                Calendar.getInstance().get(Calendar.DAY_OF_MONTH)
+        );
+        datePickerDialog.show();
+    }
+
+    @Override
+    public void onDateSet(DatePicker view, int year, int month, int day) {
+        int correctedMonth = month + 1;
+        String date = day + "/" + correctedMonth + "/" + year;
+        _habitDateTextView.setText(date);
+    }
+
     @Override
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);

--- a/app/src/main/res/layout/add_habit_dialog_box.xml
+++ b/app/src/main/res/layout/add_habit_dialog_box.xml
@@ -114,7 +114,7 @@
         android:background="@color/white"
         android:clickable="true"
         android:onClick="onClick"
-        android:text="@string/habit_date"
+        android:hint="@string/habit_date"
         android:textSize="18dp"
         android:textColor="@color/grey"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/add_habit_dialog_box.xml
+++ b/app/src/main/res/layout/add_habit_dialog_box.xml
@@ -116,6 +116,7 @@
         android:onClick="onClick"
         android:text="@string/habit_date"
         android:textSize="18dp"
+        android:textColor="@color/grey"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/habit_reason_edit_text"
         app:layout_constraintTop_toBottomOf="@+id/habit_reason_edit_text" />

--- a/app/src/main/res/layout/add_habit_dialog_box.xml
+++ b/app/src/main/res/layout/add_habit_dialog_box.xml
@@ -39,49 +39,26 @@
         app:layout_constraintTop_toBottomOf="@+id/habit_title_edit_text"
         tools:ignore="MissingConstraints" />
 
-    <EditText
-        android:id="@+id/habit_date_edit_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="28dp"
-        android:layout_marginEnd="24dp"
-        android:focusable="true"
-        android:background="@color/white"
-        android:clickable="false"
-        android:ems="10"
-        android:hint="@string/dd_mm_yyyy"
-        android:inputType="date"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="@+id/habit_reason_edit_text"
-        app:layout_constraintTop_toBottomOf="@+id/habit_reason_edit_text"
-        tools:ignore="MissingConstraints" />
-
     <Button
         android:id="@+id/confirm_habit"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="30dp"
-        android:layout_marginBottom="16dp"
         android:background="@color/habit_list_text"
         android:text="@string/confirm"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/habit_date_edit_text"
-        app:layout_constraintTop_toBottomOf="@+id/habit_date_edit_text" />
+        app:layout_constraintStart_toStartOf="@+id/habit_date_selection"
+        app:layout_constraintTop_toBottomOf="@+id/habit_date_selection" />
 
     <Button
         android:id="@+id/cancel_habit"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="15dp"
-        android:layout_marginTop="30dp"
-        android:layout_marginBottom="16dp"
         android:background="@color/habit_list_text"
         android:text="@string/cancel"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@+id/habit_date_edit_text"
         app:layout_constraintStart_toEndOf="@+id/confirm_habit"
-        app:layout_constraintTop_toBottomOf="@+id/habit_date_edit_text" />
+        app:layout_constraintTop_toBottomOf="@+id/habit_date_selection" />
 
     <TextView
         android:id="@+id/habit_name_text_view"
@@ -109,10 +86,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/date_start"
-        app:layout_constraintEnd_toStartOf="@+id/habit_date_edit_text"
-        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintEnd_toEndOf="@+id/habit_reason_text_view"
         app:layout_constraintStart_toStartOf="@+id/habit_reason_text_view"
-        app:layout_constraintTop_toTopOf="@+id/habit_date_edit_text" />
+        app:layout_constraintTop_toTopOf="@+id/habit_date_selection" />
 
     <TextView
         android:id="@+id/add_habit_header"
@@ -124,4 +100,18 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/habit_date_selection"
+        android:layout_width="211dp"
+        android:layout_height="37dp"
+        android:layout_marginTop="28dp"
+        android:layout_marginEnd="24dp"
+        android:background="@color/white"
+        android:clickable="true"
+        android:onClick="onClick"
+        android:text="@string/habit_date"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/habit_reason_edit_text"
+        app:layout_constraintTop_toBottomOf="@+id/habit_reason_edit_text" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/add_habit_dialog_box.xml
+++ b/app/src/main/res/layout/add_habit_dialog_box.xml
@@ -43,6 +43,8 @@
         android:id="@+id/confirm_habit"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="30dp"
+        android:layout_marginBottom="16dp"
         android:background="@color/habit_list_text"
         android:text="@string/confirm"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -54,6 +56,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="15dp"
+        android:layout_marginTop="30dp"
+        android:layout_marginBottom="16dp"
         android:background="@color/habit_list_text"
         android:text="@string/cancel"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -67,7 +71,7 @@
         android:layout_marginStart="16dp"
         android:text="@string/name"
         app:layout_constraintEnd_toStartOf="@+id/habit_title_edit_text"
-        app:layout_constraintHorizontal_bias="0.047"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/habit_title_edit_text" />
 

--- a/app/src/main/res/layout/add_habit_dialog_box.xml
+++ b/app/src/main/res/layout/add_habit_dialog_box.xml
@@ -107,14 +107,15 @@
 
     <TextView
         android:id="@+id/habit_date_selection"
-        android:layout_width="211dp"
-        android:layout_height="37dp"
+        android:layout_width="208dp"
+        android:layout_height="27dp"
         android:layout_marginTop="28dp"
         android:layout_marginEnd="24dp"
         android:background="@color/white"
         android:clickable="true"
         android:onClick="onClick"
         android:text="@string/habit_date"
+        android:textSize="18dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/habit_reason_edit_text"
         app:layout_constraintTop_toBottomOf="@+id/habit_reason_edit_text" />


### PR DESCRIPTION
When adding a new habit, the user can now choose the start date through a date selector, by clicking on the text view "Habit Date". This PR closes #55.

Dialog box:
![CMPUT301HabitSmasher#55 1](https://user-images.githubusercontent.com/77360509/138634405-81a890a3-94d7-47c6-9642-49fe975ee75b.PNG)

Date Selector after pressing on text view "Habit Date"
![CMPUT301HabitSmasher#55 2](https://user-images.githubusercontent.com/77360509/138634355-a5f52739-4767-48cf-be89-c3bd2ae8f04c.PNG)

Dialog after date is selected:
![CMPUT301HabitSmasher#55 3](https://user-images.githubusercontent.com/77360509/138634596-4e153fa0-a628-4553-a7de-ebc6da729429.PNG)
