### PR TITLE
Fixed navigation bug and allowed for up/back navigation

### DIFF
--- a/app/src/androidTest/java/com/example/habitsmasher/MainActivityTest.java
+++ b/app/src/androidTest/java/com/example/habitsmasher/MainActivityTest.java
@@ -12,6 +12,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
 /**
  * Test class for MainActivity. All the UI tests are written here. Robotium test framework is
  used
@@ -50,10 +54,10 @@ public class MainActivityTest {
         solo.assertCurrentActivity("Wrong Activity", MainActivity.class);
 
         // click on the Habit List tab in the bottom navigation bar
-        solo.clickOnText("Habit List");
+        solo.clickOnView(solo.getView(R.id.navigation_dashboard));
 
         // ensure that the app has transitioned to the Habit List screen
-        assertTrue(solo.waitForText("Habit List", 2, 2000));
+        assertTrue(solo.waitForText("Habit List", 1, 2000));
     }
 
     /**
@@ -65,10 +69,10 @@ public class MainActivityTest {
         solo.assertCurrentActivity("Wrong Activity", MainActivity.class);
 
         // click on the Notifications tab in the bottom navigation bar
-        solo.clickOnText("Profile");
+        solo.clickOnView(solo.getView(R.id.navigation_notifications));
 
         // ensure that the app has transitioned to the Notifications screen
-        assertTrue(solo.waitForText("Profile", 2, 2000));
+        assertTrue(solo.waitForText("Profile", 1, 2000));
     }
 
     /**
@@ -80,6 +84,57 @@ public class MainActivityTest {
         solo.assertCurrentActivity("Wrong Activity", MainActivity.class);
 
         // ensure that the app has transitioned to the Notifications screen
-        assertTrue(solo.waitForText("Home", 2, 2000));
+        assertTrue(solo.waitForText("Home", 1, 2000));
+    }
+
+    @Test
+    public void navigateToHabitViewFragment() {
+        // Asserts that the current activity is the MainActivity. Otherwise, show “Wrong Activity”
+        solo.assertCurrentActivity("Wrong Activity", MainActivity.class);
+
+        // click on the Habit List tab in the bottom navigation bar
+        solo.clickOnView(solo.getView(R.id.navigation_dashboard));
+
+        // click on add habit floating action button to add habit
+        solo.clickOnView(solo.getView(R.id.add_habit_fab));
+
+        // Create test habit
+        Habit testHabit = new Habit("addHabitToListTest", "Test Reason", new Date());
+
+        // Format the date
+        String pattern = "dd-MM-yyyy";
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
+
+        // Enter title
+        solo.enterText(solo.getEditText("Habit title"), testHabit.getTitle());
+
+        // Enter reason
+        solo.enterText(solo.getEditText("Habit reason"), testHabit.getReason());
+
+        // Enter date
+        solo.enterText(solo.getEditText("dd-mm-yyyy"), simpleDateFormat.format(testHabit.getDate()));
+
+        // Click confirm
+        solo.clickOnView(solo.getView(R.id.confirm_habit));
+
+        // Click on added Habit
+        solo.clickOnText(testHabit.getTitle());
+
+        // Check that the viewHabitFragment has loaded
+        assertTrue(solo.waitForText("HabitViewFragment", 1, 2000));
+
+        // Check that reason is correct
+        assertTrue(solo.waitForText(testHabit.getReason(), 1, 2000));
+
+        // Check that the date is correct
+        assertTrue(solo.waitForText(simpleDateFormat.format(testHabit.getDate()), 1, 2000));
+
+        // Click up/back button
+        solo.goBack();
+
+        // Check that the current fragment is the habit list
+        assertTrue(solo.waitForText("Habit List", 1, 2000));
+
+
     }
 }

--- a/app/src/main/java/com/example/habitsmasher/Habit.java
+++ b/app/src/main/java/com/example/habitsmasher/Habit.java
@@ -2,13 +2,14 @@ package com.example.habitsmasher;
 
 import com.google.firebase.firestore.PropertyName;
 
+import java.io.Serializable;
 import java.util.Date;
 
 /**
  * This is the Habit class
  * Its purpose is to store and retrieve the title, reason, and date of a given habit
  */
-public class Habit {
+public class Habit implements Serializable {
     private String _title;
     private String _reason;
     private Date _date;

--- a/app/src/main/java/com/example/habitsmasher/MainActivity.java
+++ b/app/src/main/java/com/example/habitsmasher/MainActivity.java
@@ -16,6 +16,7 @@ import com.example.habitsmasher.databinding.ActivityMainBinding;
 public class MainActivity extends AppCompatActivity {
 
     private ActivityMainBinding binding;
+    AppBarConfiguration appBarConfiguration;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -27,9 +28,10 @@ public class MainActivity extends AppCompatActivity {
         BottomNavigationView navView = findViewById(R.id.nav_view);
         // Passing each menu ID as a set of Ids because each
         // menu should be considered as top level destinations.
-        AppBarConfiguration appBarConfiguration = new AppBarConfiguration.Builder(
+        appBarConfiguration = new AppBarConfiguration.Builder(
                 R.id.navigation_home, R.id.navigation_dashboard, R.id.navigation_notifications)
                 .build();
+
         NavHostFragment navHostFragment = (NavHostFragment) getSupportFragmentManager().findFragmentById(R.id.nav_host_fragment_activity_main);
         NavController navController;
         if (navHostFragment != null) {
@@ -37,7 +39,16 @@ public class MainActivity extends AppCompatActivity {
             NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
             NavigationUI.setupWithNavController(binding.navView, navController);
         }
-
     }
 
+    /**
+     * This function allows for the user to navigate back/up
+     * @return
+     */
+    @Override
+    public boolean onSupportNavigateUp() {
+        NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment_activity_main);
+        return NavigationUI.navigateUp(navController, appBarConfiguration)
+                || super.onSupportNavigateUp();
+    }
 }

--- a/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitItemAdapter.java
+++ b/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitItemAdapter.java
@@ -1,6 +1,7 @@
 package com.example.habitsmasher.ui.dashboard;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -9,7 +10,8 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.fragment.app.FragmentActivity;
-import androidx.fragment.app.FragmentTransaction;
+import androidx.navigation.NavController;
+import androidx.navigation.fragment.NavHostFragment;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.habitsmasher.Habit;
@@ -26,6 +28,7 @@ public class HabitItemAdapter extends FirestoreRecyclerAdapter<Habit, HabitItemA
     private Context _context;
     private static HabitList _habits;
     private final FragmentActivity _activity;
+    private HabitListFragment _habitListFragment;
     private final ObservableSnapshotArray<Habit> _snapshots;
 
     /**
@@ -33,11 +36,13 @@ public class HabitItemAdapter extends FirestoreRecyclerAdapter<Habit, HabitItemA
      * FirestoreRecyclerOptions} for configuration options.
      *
      * @param options the firestore entities
+     * @param habitListFragment the habitListFragment
      */
-    public HabitItemAdapter(@NonNull FirestoreRecyclerOptions<Habit> options, FragmentActivity activity) {
+    public HabitItemAdapter(@NonNull FirestoreRecyclerOptions<Habit> options, FragmentActivity activity, HabitListFragment habitListFragment) {
         super(options);
         _snapshots = options.getSnapshots();
         _activity = activity;
+        _habitListFragment = habitListFragment;
     }
 
     @NonNull
@@ -75,14 +80,15 @@ public class HabitItemAdapter extends FirestoreRecyclerAdapter<Habit, HabitItemA
      * This is the position of the selected habit item
      */
     private void openHabitView(HabitViewHolder holder, int position) {
+        // Get the selected habit
         Habit currentHabit = _snapshots.get(position);
-        // Create Habit View Fragment with all required parameters passed in
-        HabitViewFragment fragment = HabitViewFragment.newInstance(currentHabit.getReason(), currentHabit.getDate().toString());
-        // Replace the current fragment with the habit view
-        FragmentTransaction transaction = _activity.getSupportFragmentManager().beginTransaction().replace(R.id.nav_host_fragment_activity_main, fragment);
-        transaction.addToBackStack(null);
-        // Load new fragment
-        transaction.commit();
+
+        // Create a bundle to be passed into the habitViewFragment
+        Bundle bundle = new Bundle();
+        bundle.putSerializable("habit", currentHabit);
+        NavController controller = NavHostFragment.findNavController(_habitListFragment);
+        // Navigate to the habitViewFragment
+        controller.navigate(R.id.action_navigation_dashboard_to_habitViewFragment, bundle);
     }
 
     @Override

--- a/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitListFragment.java
+++ b/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitListFragment.java
@@ -47,7 +47,7 @@ public class HabitListFragment extends Fragment {
         FirestoreRecyclerOptions<Habit> options = new FirestoreRecyclerOptions.Builder<Habit>()
                 .setQuery(_db.collection("Habits"), Habit.class)
                 .build();
-        _habitItemAdapter = new HabitItemAdapter(options, getActivity());
+        _habitItemAdapter = new HabitItemAdapter(options, getActivity(), this);
 
         LinearLayoutManager layoutManager = new LinearLayoutManager(context,
                                                                     LinearLayoutManager.VERTICAL,

--- a/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitViewFragment.java
+++ b/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitViewFragment.java
@@ -6,59 +6,40 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+
+import com.example.habitsmasher.Habit;
 import com.example.habitsmasher.R;
+
+import java.text.SimpleDateFormat;
 
 /**
  * This class handles the Habit View Fragment
  */
 public class HabitViewFragment extends Fragment {
 
-    private static final String REASON_PARAM = "habitReason";
-    private static final String DATE_PARAM = "habitDate";
-
-    private String _habitReason;
-    private String _habitDate;
+    private Habit _habit;
 
     public HabitViewFragment() {
         // Required empty public constructor
     }
 
-    /**
-     * Use this factory method to create a new instance of
-     * this fragment using the provided parameters.
-     *
-     * @param habitReason Reason of habit.
-     * @param habitDate Date of habit.
-     * @return A new instance of fragment HabitViewFragment.
-     */
-    public static HabitViewFragment newInstance(String habitReason, String habitDate) {
-        HabitViewFragment fragment = new HabitViewFragment();
-        Bundle args = new Bundle();
-        args.putString(REASON_PARAM,habitReason);
-        args.putString(DATE_PARAM,habitDate);
-        fragment.setArguments(args);
-        return fragment;
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        // Gets arguments for the created fragment that were set using newInstance()
-        if (getArguments() != null) {
-            _habitReason = getArguments().getString(REASON_PARAM);
-            _habitDate = getArguments().getString(DATE_PARAM);
-        }
-    }
-
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+        // Get passed in habit
+        if(getArguments() != null) {
+            _habit = (Habit) getArguments().getSerializable("habit");
+        }
+
+        String pattern = "dd-MM-yyyy";
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
+
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_habit_view, container, false);
         TextView descriptionHabitTextBox = view.findViewById(R.id.descriptionHabitTextBox);
         TextView dateHabitTextBox = view.findViewById(R.id.dateHabitTextBox);
-        descriptionHabitTextBox.setText(_habitReason);
-        dateHabitTextBox.setText(String.format(dateHabitTextBox.getText().toString(), _habitDate));
+        descriptionHabitTextBox.setText(_habit.getReason());
+        dateHabitTextBox.setText(String.format(dateHabitTextBox.getText().toString(), simpleDateFormat.format(_habit.getDate())));
         return view;
     }
 }

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -15,11 +15,20 @@
         android:id="@+id/navigation_dashboard"
         android:name="com.example.habitsmasher.ui.dashboard.HabitListFragment"
         android:label="@string/habit_list"
-        tools:layout="@layout/fragment_habit_list" />
+        tools:layout="@layout/fragment_habit_list" >
+        <action
+            android:id="@+id/action_navigation_dashboard_to_habitViewFragment"
+            app:destination="@id/habitViewFragment"
+            app:popUpTo="@id/navigation_dashboard"/>
+    </fragment>
 
     <fragment
         android:id="@+id/navigation_notifications"
         android:name="com.example.habitsmasher.ui.profile.ProfileFragment"
         android:label="@string/profile"
         tools:layout="@layout/fragment_profile" />
+    <fragment
+        android:id="@+id/habitViewFragment"
+        android:name="com.example.habitsmasher.ui.dashboard.HabitViewFragment"
+        android:label="HabitViewFragment" />
 </navigation>


### PR DESCRIPTION
In this PR I have implemented the changes necessary to allow the user to navigate properly throughout the app. The user is able to navigate using the bottom nav bar as well as up/back with the button in the action bar. This closes #61.

I have included a UI test to verify that the functionality works. It creates a new habit every time however, it will just overwrite itself in the db.

The following is a screenshot of some of the visual changes:
![Screenshot_1635195900](https://user-images.githubusercontent.com/34036324/138770754-3a162c60-314c-4124-a847-8964e507f9c0.png)

When navigating to another fragment use the following statement: 
NavController controller = NavHostFragment.findNavController({insert current fragment});
controller.navigate(R.id.{insert action}, {insert bundle});

This lets the user utilize the [navigation graph](https://developer.android.com/guide/navigation/navigation-getting-started) to create links (actions) between fragments.

The following is a screenshot of our current nav graph:
<img width="688" alt="Screen Shot 2021-10-25 at 4 14 48 PM" src="https://user-images.githubusercontent.com/34036324/138778445-70b3b4a1-a2f4-4159-b2d5-9b8ec3b6b6e6.png">

You can specify how the fragments are linked and subsequently that creates an "action".
Please look at my comment in the mobile_navigation.xml to see where the action is located.