### PR TITLE
Title of habit view now shows habit title

### DIFF
--- a/app/src/androidTest/java/com/example/habitsmasher/MainActivityTest.java
+++ b/app/src/androidTest/java/com/example/habitsmasher/MainActivityTest.java
@@ -120,8 +120,8 @@ public class MainActivityTest {
         // Click on added Habit
         solo.clickOnText(testHabit.getTitle());
 
-        // Check that the viewHabitFragment has loaded
-        assertTrue(solo.waitForText("HabitViewFragment", 1, 2000));
+        // Check the title is correct
+        assertTrue(solo.waitForText(testHabit.getTitle(), 1, 2000));
 
         // Check that reason is correct
         assertTrue(solo.waitForText(testHabit.getReason(), 1, 2000));

--- a/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitViewFragment.java
+++ b/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitViewFragment.java
@@ -1,6 +1,8 @@
 package com.example.habitsmasher.ui.dashboard;
 
 import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -31,13 +33,21 @@ public class HabitViewFragment extends Fragment {
             _habit = (Habit) getArguments().getSerializable("habit");
         }
 
+        // Date formatter
         String pattern = "dd-MM-yyyy";
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
 
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_habit_view, container, false);
+
+        // Grab text boxes
         TextView descriptionHabitTextBox = view.findViewById(R.id.descriptionHabitTextBox);
         TextView dateHabitTextBox = view.findViewById(R.id.dateHabitTextBox);
+
+        // Setting title of fragment to habit title
+        ((AppCompatActivity) requireActivity()).getSupportActionBar().setTitle(_habit.getTitle());
+
+        // Setting text boxes
         descriptionHabitTextBox.setText(_habit.getReason());
         dateHabitTextBox.setText(String.format(dateHabitTextBox.getText().toString(), simpleDateFormat.format(_habit.getDate())));
         return view;


### PR DESCRIPTION
The title of the habit view now shows the habit title rather than the text "HabitViewFragment". This closes #73.

The associated UI test was also updated to account for this change.

Screenshot of habit view now:
![Screenshot_1635202784](https://user-images.githubusercontent.com/34036324/138782192-158c60a7-2385-4848-bf8c-ecee161b86e0.png)

