### PR TITLE
Extracting habit input validation to a validator

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -52,7 +57,10 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
     implementation 'com.google.firebase:firebase-firestore:23.0.4'
     implementation "io.grpc:grpc-okhttp:1.32.2"
+    implementation 'androidx.test:monitor:1.4.0'
     testImplementation 'junit:junit:4.+'
+    testImplementation 'org.mockito:mockito-core:3.10.0'
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/app/src/main/java/com/example/habitsmasher/ui/dashboard/AddHabitDialog.java
+++ b/app/src/main/java/com/example/habitsmasher/ui/dashboard/AddHabitDialog.java
@@ -19,14 +19,9 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.fragment.app.DialogFragment;
 
-import com.example.habitsmasher.Habit;
 import com.example.habitsmasher.R;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.util.Date;
 
 /**
  * Making a dialogfragment from fragment came from the following video:
@@ -44,18 +39,11 @@ import java.util.Date;
 public class AddHabitDialog extends DialogFragment implements DatePickerDialog.OnDateSetListener {
 
     private static final String TAG = "AddHabitDialog";
-    private final String DATE_FORMAT = "dd/MM/yyyy";
-    private final String INCORRECT_TITLE_FORMAT = "Incorrect habit title entered";
-    private final String INCORRECT_REASON_FORMAT = "Incorrect habit reason entered";
-    private final String INCORRECT_BLANK_DATE = "Please enter a start date";
 
     private HabitListFragment _habitListFragment;
     private EditText _habitTitleEditText;
     private EditText _habitReasonEditText;
     private TextView _habitDateTextView;
-    private String _habitTitleInput;
-    private String _habitReasonInput;
-    private Date _habitDate;
 
     @Nullable
     @Override
@@ -87,8 +75,19 @@ public class AddHabitDialog extends DialogFragment implements DatePickerDialog.O
             @Override
             public void onClick(View view) {
                 Log.d(TAG, "Confirm");
-                if (checkNewHabitIsValid()){
-                    _habitListFragment.addHabitToDatabase(_habitTitleInput, _habitReasonInput, _habitDate);
+
+                HabitValidator habitValidator = new HabitValidator(getActivity());
+
+                String habitTitle = _habitTitleEditText.getText().toString();
+                String habitReason = _habitReasonEditText.getText().toString();
+                String habitDate = _habitDateTextView.getText().toString();
+
+                if (habitValidator.isHabitValid(habitTitle,
+                                                habitReason,
+                                                habitDate)){
+                    _habitListFragment.addHabitToDatabase(habitTitle,
+                                                          habitReason,
+                                                          habitValidator.checkHabitDateValid(habitDate));
                     getDialog().dismiss();
                 }
             }
@@ -117,56 +116,6 @@ public class AddHabitDialog extends DialogFragment implements DatePickerDialog.O
         int correctedMonth = month + 1;
         String date = day + "/" + correctedMonth + "/" + year;
         _habitDateTextView.setText(date);
-    }
-
-    /**
-     * Returns boolean so habit can be added to habit list or not.
-     * @return true if all fields are entered correctly, false otherwise.
-     */
-    private boolean checkNewHabitIsValid(){
-        boolean invalidDate = false;
-        _habitTitleInput = _habitTitleEditText.getText().toString();
-        _habitReasonInput = _habitReasonEditText.getText().toString();
-
-        DateFormat inputDateFormatter = new SimpleDateFormat(DATE_FORMAT);
-        _habitDate = null;
-
-        try {
-            inputDateFormatter.setLenient(false);
-            _habitDate = inputDateFormatter.parse(_habitDateTextView.getText().toString());
-        } catch (ParseException e) {
-            invalidDate = true;
-            e.printStackTrace();
-        }
-
-        /**
-         * When user input meets the requirements for a proper habit title, habit reason, and habit date,
-         * have the habit be added to the habit list back in dashboard fragment.
-         */
-        if (
-                ((_habitTitleInput.length()>0)&&(_habitTitleInput.length()<=20))&&
-                ((_habitReasonInput.length()>0)&&(_habitReasonInput.length()<=30))&&
-                (!invalidDate)
-        ) {
-            return true;
-        } else {
-
-            //Handle error checking for new habit name/title
-            if ((!(_habitTitleInput.length()>0)) || (!(_habitTitleInput.length()<=20))){
-                Toast.makeText(getActivity(), INCORRECT_TITLE_FORMAT, Toast.LENGTH_SHORT).show();
-            }
-
-            //Handle error checking for new habit reason
-            if ((!(_habitReasonInput.length()>0)) || (!(_habitReasonInput.length()<=30))){
-                Toast.makeText(getActivity(), INCORRECT_REASON_FORMAT, Toast.LENGTH_SHORT).show();
-            }
-
-            //Handle error checking for new habit date.
-            if (invalidDate){
-                Toast.makeText(getActivity(), INCORRECT_BLANK_DATE, Toast.LENGTH_SHORT).show();
-            }
-            return false;
-        }
     }
 
     @Override

--- a/app/src/main/java/com/example/habitsmasher/ui/dashboard/EditHabitFragment.java
+++ b/app/src/main/java/com/example/habitsmasher/ui/dashboard/EditHabitFragment.java
@@ -22,32 +22,21 @@ import com.example.habitsmasher.R;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
 
-import com.google.firebase.firestore.CollectionReference;
-import com.google.firebase.firestore.FirebaseFirestore;
 
 public class EditHabitFragment extends DialogFragment implements DatePickerDialog.OnDateSetListener{
     private static final String HEADER = "Edit Dialog";
     private static final String PATTERN = "dd/MM/yyyy";
-    private final String INCORRECT_TITLE_FORMAT = "Incorrect habit title entered";
-    private final String INCORRECT_REASON_FORMAT = "Incorrect habit reason entered";
-    private final String INCORRECT_BLANK_DATE = "Please enter a start date";
     private EditText _titleText;
     private EditText _reasonText;
     private TextView _dateText;
-    private TextView _header;
 
-    private Button _confirmButton;
-    private Button _cancelButton;
-
-    private Habit _editHabit;
-    private int _index;
-    private HabitListFragment _listener;
+    private final Habit _editHabit;
+    private final int _index;
+    private final HabitListFragment _listener;
     // viewHolder of edited Habit
-    private HabitItemAdapter.HabitViewHolder _viewHolder;
+    private final HabitItemAdapter.HabitViewHolder _viewHolder;
 
     public EditHabitFragment(int index, Habit editHabit, HabitListFragment listener,
                                 HabitItemAdapter.HabitViewHolder habitViewHolder) {
@@ -65,14 +54,14 @@ public class EditHabitFragment extends DialogFragment implements DatePickerDialo
         View view = inflater.inflate(R.layout.add_habit_dialog_box, container, false);
 
         // Connecting elements on UI xml to variables
-        _header = view.findViewById(R.id.add_habit_header);
+        TextView header = view.findViewById(R.id.add_habit_header);
+        Button confirmButton = view.findViewById(R.id.confirm_habit);
+        Button cancelButton = view.findViewById(R.id.cancel_habit);
         _titleText = view.findViewById(R.id.habit_title_edit_text);
         _reasonText = view.findViewById(R.id.habit_reason_edit_text);
         _dateText = view.findViewById(R.id.habit_date_selection);
-        _confirmButton = view.findViewById(R.id.confirm_habit);
-        _cancelButton = view.findViewById(R.id.cancel_habit);
 
-        _header.setText(HEADER);
+        header.setText(HEADER);
 
         // presetting text to values of habit
         _titleText.setText(_editHabit.getTitle());
@@ -87,7 +76,7 @@ public class EditHabitFragment extends DialogFragment implements DatePickerDialo
         });
 
         // when ok is clicked
-        _confirmButton.setOnClickListener(new View.OnClickListener() {
+        confirmButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 //HashMap<String, Habit> habitData = new HashMap<>();
@@ -95,29 +84,21 @@ public class EditHabitFragment extends DialogFragment implements DatePickerDialo
                 String reasonText = _reasonText.getText().toString();
                 String dateText = _dateText.getText().toString();
 
-                // need to set to constant later
-                if (habitTitle.length() > 30 || habitTitle.length() == 0){
-                    Toast.makeText(getActivity(), INCORRECT_TITLE_FORMAT, Toast.LENGTH_SHORT).show();
+                HabitValidator habitValidator = new HabitValidator(getActivity());
+
+                if (!habitValidator.isHabitValid(habitTitle, reasonText, dateText)) {
                     return;
                 }
-                if (reasonText.length() > 30 || reasonText.length() == 0) {
-                    Toast.makeText(getActivity(), INCORRECT_REASON_FORMAT, Toast.LENGTH_SHORT).show();
-                    return;
-                }
-                Date habitDate = parseStringToDate(dateText);
-                if (habitDate == null) {
-                    Toast.makeText(getActivity(), INCORRECT_BLANK_DATE, Toast.LENGTH_SHORT).show();
-                    return;
-                }
+
                 // update local list and display
-                _listener.updateAfterEdit(habitTitle, reasonText, habitDate, _index, _viewHolder);
+                _listener.updateAfterEdit(habitTitle, reasonText, parseStringToDate(dateText), _index, _viewHolder);
 
                 getDialog().dismiss();
             }
         });
 
         // when cancel button is clicked
-        _cancelButton.setOnClickListener(new View.OnClickListener() {
+        cancelButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 getDialog().dismiss();

--- a/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitListFragment.java
+++ b/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitListFragment.java
@@ -112,10 +112,9 @@ public class HabitListFragment extends Fragment {
      */
     @NonNull
     private Query getListOfHabitsFromFirebase(String username) {
-        Query query = _db.collection("Users")
-                         .document(username)
-                         .collection("Habits");
-        return query;
+        return _db.collection("Users")
+                  .document(username)
+                  .collection("Habits");
     }
 
     @Override public void onStart() {

--- a/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitValidator.java
+++ b/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitValidator.java
@@ -1,0 +1,87 @@
+package com.example.habitsmasher.ui.dashboard;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.widget.Toast;
+
+import androidx.fragment.app.FragmentActivity;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * This class serves as a validator for all the habit input fields
+ */
+public class HabitValidator {
+    private final FragmentActivity _context;
+
+    public HabitValidator(FragmentActivity context) {
+        _context = context;
+    }
+
+    /**
+     * This method checks if a habit with the specified fields are valid
+     * @param habitTitle the habit title
+     * @param habitReason the habit reason
+     * @param habitDate the habit date
+     * @return true, if habit is valid, false otherwise
+     */
+    public boolean isHabitValid(String habitTitle,
+                                String habitReason,
+                                String habitDate) {
+        Date parsedDate = checkHabitDateValid(habitDate);
+
+        if ((habitTitle.length() <= 0) || (habitTitle.length() > 20)) {
+            showToastMessage("Incorrect habit title entered");
+            return false;
+        }
+
+        if ((habitReason.length() <= 0) || (habitReason.length() > 30)) {
+            showToastMessage("Incorrect habit reason entered");
+            return false;
+        }
+
+        if (parsedDate == null) {
+            showToastMessage("Please enter a start date");
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * This helper method displays a message to the screen
+     * @param message the message to display
+     */
+    private void showToastMessage(String message) {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                Toast toast = Toast.makeText(_context, message, Toast.LENGTH_SHORT);
+                toast.show();
+            }
+        });
+    }
+
+    /**
+     * This helper method parses a given date in string form
+     * @param date the habit date
+     * @return correctly parsed date, null otherwise
+     */
+    public Date checkHabitDateValid(String date) {
+        Date parsedDate;
+        DateFormat inputDateFormatter = new SimpleDateFormat("dd/MM/yyyy");
+
+        try {
+            inputDateFormatter.setLenient(false);
+            parsedDate = inputDateFormatter.parse(date);
+        } catch (ParseException e) {
+            e.printStackTrace();
+            return null;
+        }
+
+        return parsedDate;
+    }
+}

--- a/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitValidator.java
+++ b/app/src/main/java/com/example/habitsmasher/ui/dashboard/HabitValidator.java
@@ -53,6 +53,10 @@ public class HabitValidator {
 
     /**
      * This helper method displays a message to the screen
+     * Implementation from:
+     * https://stackoverflow.com/questions/3875184/cant-create-handler-inside-thread-that-has-not-called-looper-prepare
+     * User: Ayaz Alifov
+     * Date: January 24, 2016
      * @param message the message to display
      */
     private void showToastMessage(String message) {

--- a/app/src/test/java/com/example/habitsmasher/HabitSmasherTestSuite.java
+++ b/app/src/test/java/com/example/habitsmasher/HabitSmasherTestSuite.java
@@ -2,10 +2,14 @@ package com.example.habitsmasher;
 
 import com.example.habitsmasher.test.UserUnitTest;
 import com.example.habitsmasher.ui.dashboard.HabitListTest;
+import com.example.habitsmasher.ui.dashboard.HabitValidatorTest;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({HabitListTest.class, UserUnitTest.class})
+@Suite.SuiteClasses({HabitListTest.class,
+                     UserUnitTest.class,
+                     HabitValidatorTest.class})
 public class HabitSmasherTestSuite {
 }

--- a/app/src/test/java/com/example/habitsmasher/ui/dashboard/HabitValidatorTest.java
+++ b/app/src/test/java/com/example/habitsmasher/ui/dashboard/HabitValidatorTest.java
@@ -1,0 +1,73 @@
+package com.example.habitsmasher.ui.dashboard;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import androidx.fragment.app.FragmentActivity;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class HabitValidatorTest {
+    private static final Locale LOCALE = Locale.CANADA;
+    private static final String GOOD_TITLE = "Good title";
+    private static final String GOOD_REASON = "Good reason";
+    private static final String LONG_TITLE = "This title is toooooooooooooooooooooo long";
+    private static final String LONG_REASON = "This reason is toooooooooooooooooooooooooooooo long";
+    private static final String TITLE_20_CHARACTERS = "01234567890123456789";
+    private static final String REASON_30_CHARACTERS = "012345678901234567890123456789";
+    private static final String DATE_PATTERN = "dd/MM/yyyy";
+    private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat(DATE_PATTERN, LOCALE);
+    private static final String TODAY = SIMPLE_DATE_FORMAT.format(new Date());
+
+    private HabitValidator _validator;
+
+    @Before
+    public void setUp() {
+        _validator = new HabitValidator(mock(FragmentActivity.class));
+    }
+
+    @Test
+    public void isHabitValid_allFieldsValid_expectHabitIsValid() {
+        assertTrue(_validator.isHabitValid(GOOD_TITLE, GOOD_REASON, TODAY));
+    }
+
+    @Test
+    public void isHabitValid_emptyTitle_expectHabitIsInvalid() {
+        assertFalse(_validator.isHabitValid("", GOOD_REASON, TODAY));
+    }
+
+    @Test
+    public void isHabitValid_emptyReason_expectHabitIsInvalid() {
+        assertFalse(_validator.isHabitValid(GOOD_TITLE, "", TODAY));
+    }
+
+    @Test
+    public void isHabitValid_emptyDate_expectHabitIsInvalid() {
+        assertFalse(_validator.isHabitValid(GOOD_TITLE, GOOD_REASON, ""));
+    }
+
+    @Test
+    public void isHabitValid_titleTooLong_expectHabitIsInvalid() {
+        assertFalse(_validator.isHabitValid(LONG_TITLE, GOOD_REASON, TODAY));
+    }
+
+    @Test
+    public void isHabitValid_reasonTooLong_expectHabitIsInvalid() {
+        assertFalse(_validator.isHabitValid(GOOD_TITLE, LONG_REASON, TODAY));
+    }
+
+    @Test
+    public void isHabitValid_titleExactly20Characters_expectHabitIsValid() {
+        assertTrue(_validator.isHabitValid(TITLE_20_CHARACTERS, GOOD_REASON, TODAY));
+    }
+
+    @Test
+    public void isHabitValid_reasonExactly30Characters_expectHabitIsValid() {
+        assertTrue(_validator.isHabitValid(GOOD_TITLE, REASON_30_CHARACTERS, TODAY));
+    }
+}


### PR DESCRIPTION
### What is it?
In this PR, the **shared validation logic** between the add/edit habit paths has been extracted into its own class. The UI test provides a good safety net for this change, as all of them still pass, along with the new unit tests included here.

### Testing scenarios
I've gone ahead and noted all testing scenarios below:
* all fields valid, habit valid
* empty title, habit invalid
* empty reason, habit invalid
* empty date, habit invalid
* title too long, habit invalid
* reason too long, habit invalid
* title exactly 20 characters, habit valid
* reason exactly 30 characters, habit valid

This PR also closes #78!