### PR TITLE
Update android.yml to include all branches

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,9 +2,12 @@ name: Android CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - develop
   pull_request:
-    branches: [ main ]
+    branches:
+      - '*'
 
 jobs:
   build:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,9 @@ android {
     buildFeatures {
         viewBinding true
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
### What is it?
When we first started the Github actions, it was only set to run on pushes/PRs on the `main` branch. This is a bit trial and error, I'm changing this to run on all PRs, regardless of branch, and **pushes** to `develop` + `main`.