### PR TITLE
Fixing NPE that occurs for some members when running UI tests

### DIFF
--- a/app/src/androidTest/java/com/example/habitsmasher/MainActivityTest.java
+++ b/app/src/androidTest/java/com/example/habitsmasher/MainActivityTest.java
@@ -1068,7 +1068,7 @@ public class MainActivityTest {
 
         _solo.clickOnButton(LOGIN_TEXT);
 
-        checkForToastMessage(PASSWORD_IS_REQUIRED);
+        assertTextOnScreen(PASSWORD_IS_REQUIRED);
     }
 
     private void deleteTestHabit(Habit habitToDelete) {

--- a/app/src/androidTest/java/com/example/habitsmasher/MainActivityTest.java
+++ b/app/src/androidTest/java/com/example/habitsmasher/MainActivityTest.java
@@ -1068,7 +1068,7 @@ public class MainActivityTest {
 
         _solo.clickOnButton(LOGIN_TEXT);
 
-        assertTextOnScreen(PASSWORD_IS_REQUIRED);
+        checkForToastMessage(PASSWORD_IS_REQUIRED);
     }
 
     private void deleteTestHabit(Habit habitToDelete) {
@@ -1216,5 +1216,6 @@ public class MainActivityTest {
         _solo.enterText(_solo.getEditText("Password"), _testUser.getPassword());
 
         _solo.clickOnButton(LOGIN_TEXT);
+        _solo.sleep(4000);
     }
 }


### PR DESCRIPTION
This PR adds a 4000ms/4 second wait after logging in to prevent a NPE that was occurring for some members when running UI tests. This resolves #122.

I highly recommend that everyone pull from this branch and run the UI tests on your own machine using the device "Pixel 5 API 29" to ensure that there are no further issues with UI tests.