### PR TITLE
Readjust progress tracking and habit title in habit rows

### DIFF
--- a/app/src/androidTest/java/com/example/habitsmasher/MainActivityTest.java
+++ b/app/src/androidTest/java/com/example/habitsmasher/MainActivityTest.java
@@ -233,7 +233,7 @@ public class MainActivityTest {
     }
 
     @Test
-    public void requestTofollowUserWithInvalidUsername(){
+    public void requestToFollowUserWithInvalidUsername(){
         logInTestUser();
 
         // Asserts that the current activity is the MainActivity. Otherwise, show “Wrong Activity”

--- a/app/src/main/res/layout/habit_row.xml
+++ b/app/src/main/res/layout/habit_row.xml
@@ -64,6 +64,7 @@
                 android:id="@+id/habit_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="-16dp"
                 android:text="@string/habit_title"
                 android:textAlignment="center"
                 android:textColor="@color/habit_list_text"
@@ -71,7 +72,7 @@
                 android:textStyle="bold"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/habit_progress_bar"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <ProgressBar

--- a/app/src/main/res/layout/home_habit_row.xml
+++ b/app/src/main/res/layout/home_habit_row.xml
@@ -53,6 +53,7 @@
                 android:id="@+id/habit_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="-16dp"
                 android:text="@string/habit_title"
                 android:textAlignment="center"
                 android:textColor="@color/habit_list_text"
@@ -60,14 +61,14 @@
                 android:textStyle="bold"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/habit_home_progress_bar"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <ProgressBar
                 android:id="@+id/habit_home_progress_bar"
                 android:layout_width="64dp"
                 android:layout_height="61dp"
-                android:layout_marginStart="32dp"
+                android:layout_marginStart="8dp"
                 android:indeterminateOnly="false"
                 android:progressDrawable="@drawable/circular_progress_determinate"
                 app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
Found that long habit titles overlapped with progress tracking during UI tests, tried to reduce that here.

Before:
![CMPUT301HabitSmasher#Testing 3](https://user-images.githubusercontent.com/77360509/143941653-f3633696-a3be-4721-bd14-c9f78e486fc4.PNG)

![CMPUT301HabitSmasher#Testing 4](https://user-images.githubusercontent.com/77360509/143941680-f22e332e-ec7e-4d1c-aba4-c0bddc895a57.PNG)

After:
![CMPUT301HabitSmasher#Testing 1](https://user-images.githubusercontent.com/77360509/143941675-78ac96b8-b24c-40b9-b778-8de08dc55101.PNG)
![CMPUT301HabitSmasher#Testing 2](https://user-images.githubusercontent.com/77360509/143941677-b611f5e3-7838-4309-9169-d99820e36577.PNG)

