### PR TITLE
Fixed instances of app crashing when opening follow user dialog when users in database had null usernames, and small changes

### DIFF
--- a/app/src/main/java/com/example/habitsmasher/FollowUserDialog.java
+++ b/app/src/main/java/com/example/habitsmasher/FollowUserDialog.java
@@ -93,9 +93,14 @@ public class FollowUserDialog extends DialogFragment implements DisplaysErrorMes
                 if (task.isSuccessful()) {
                     for (QueryDocumentSnapshot document : task.getResult()) {
                         if (document.exists()) {
-                            if (document.get(USERNAME_FIELD).toString().contains(_userToFollowACTV.getText().toString())) {
-                                Log.d(TAG, "Username exists");
-                                _usernames.add(document.get(USERNAME_FIELD).toString());
+                            try {
+                                if (document.get(USERNAME_FIELD).toString().contains(_userToFollowACTV.getText().toString())) {
+                                    Log.d(TAG, "Username exists");
+                                    _usernames.add(document.get(USERNAME_FIELD).toString());
+                                }
+                            } catch (NullPointerException exception) {
+                                Log.d(TAG, "Username is null" + exception.getMessage(), task.getException());
+                                return;
                             }
                         }
                     }

--- a/app/src/main/res/layout/add_habit_event_dialog.xml
+++ b/app/src/main/res/layout/add_habit_event_dialog.xml
@@ -139,8 +139,8 @@
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/add_location_button"
-        android:layout_width="60dp"
-        android:layout_height="60dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginTop="164dp"
         android:baselineAlignBottom="false"
         android:clickable="true"

--- a/app/src/main/res/layout/add_habit_event_dialog.xml
+++ b/app/src/main/res/layout/add_habit_event_dialog.xml
@@ -139,8 +139,8 @@
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/add_location_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
         android:layout_marginTop="164dp"
         android:baselineAlignBottom="false"
         android:clickable="true"
@@ -148,7 +148,7 @@
         android:minHeight="48dp"
         android:tint="@color/white"
         app:backgroundTint="@color/menu_bar_variant"
-        app:fabCustomSize="80dp"
+        app:fabCustomSize="60dp"
         app:layout_constraintEnd_toEndOf="@+id/add_location_label"
         app:layout_constraintStart_toStartOf="@+id/add_location_label"
         app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/add_habit_event_dialog.xml
+++ b/app/src/main/res/layout/add_habit_event_dialog.xml
@@ -94,14 +94,11 @@
         android:id="@+id/new_habit_date_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="40dp"
         android:layout_marginTop="24dp"
-        android:layout_marginEnd="20dp"
-        android:text="@string/date_start"
+        android:text="@string/date"
         android:textColor="@color/design_default_color_background"
         android:textSize="24sp"
-        app:layout_constraintEnd_toStartOf="@+id/habit_event_date_selection"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/comment_label"
         app:layout_constraintTop_toBottomOf="@+id/add_habit_event_comment" />
 
     <TextView
@@ -162,9 +159,9 @@
         android:id="@+id/habit_event_date_selection"
         android:layout_width="180dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="30dp"
-        android:layout_marginTop="32dp"
-        android:layout_marginEnd="30dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="28dp"
+        android:layout_marginEnd="40dp"
         android:background="@color/white"
         android:clickable="true"
         android:ems="10"
@@ -174,7 +171,6 @@
         android:textColor="@color/theme_dark_grey"
         android:textSize="18sp"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toEndOf="@+id/new_habit_date_label"
         app:layout_constraintTop_toBottomOf="@+id/add_habit_event_comment" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="name">Name:</string>
     <string name="reason">Reason:</string>
     <string name="date_start">Date start:</string>
+    <string name="date">Date:</string>
     <string name="add_habit">Add Habit</string>
     <string name="add_habit_event">Add Habit Event</string>
     <string name="habit_event_comment_label">Comment:</string>


### PR DESCRIPTION
Noticed that some users in the database had deleted fields(instead of deleting the whole user), as a result, they did not have a username so when we opened the FollowUserDialog, the app crashed. Put the query for the user's usernames(only for FollowUserDialog) in a try/catch to stop the app from crashing. 

**However, this doesn't need to be added, just nice to have**

Updated habit event dialog
![CMPUT301HabitSmasher#Testing 6](https://user-images.githubusercontent.com/77360509/143950059-067c5968-fffb-4725-bd72-68cfbca98d0e.PNG)

updated floating action button (now smaller)
![CMPUT301HabitSmasher#Testing 8](https://user-images.githubusercontent.com/77360509/143951343-4e1ec9e7-61c9-4fd4-86e7-92afcd68a5ee.PNG)
